### PR TITLE
fix: improve Linkage mobile compatibility

### DIFF
--- a/esystems-frontend/src/components/Layout.js
+++ b/esystems-frontend/src/components/Layout.js
@@ -67,7 +67,7 @@ export default function Layout() {
                       />
                     </Link>
                   </div>
-                  <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
+                  <div className="hidden lg:ml-6 lg:flex lg:space-x-8">
                     {navigation.map((item) => (
                       <Link
                         key={item.name}
@@ -84,10 +84,10 @@ export default function Layout() {
                     ))}
                   </div>
                 </div>
-                <div className="hidden ml-auto sm:ml-6 sm:flex sm:items-center">
+                <div className="hidden ml-auto lg:ml-6 lg:flex lg:items-center">
                     <Link to="/vas" className='bg-white hover:bg-white-600 text-black px-3 py-2 rounded-full text-sm font-medium'>Our Talent</Link>
                 </div>
-                <div className="hidden sm:ml-6 sm:flex sm:items-center">
+                <div className="hidden lg:ml-6 lg:flex lg:items-center">
                   {user ? (
                     <>
                       <button
@@ -206,7 +206,7 @@ export default function Layout() {
                     </div>
                   )}
                 </div>
-                <div className="-mr-2 flex items-center sm:hidden">
+                <div className="-mr-2 flex items-center lg:hidden">
                   <Disclosure.Button className={classNames(
                     branding.isESystemsMode 
                       ? "bg-primary-800 text-primary-400 hover:text-white hover:bg-primary-600 focus:ring-offset-primary-700 focus:ring-white"
@@ -224,7 +224,7 @@ export default function Layout() {
               </div>
             </div>
             <Disclosure.Panel className={classNames(
-              "sm:hidden",
+              "lg:hidden",
               branding.isESystemsMode ? "bg-primary-700" : "bg-white border-b border-gray-200"
             )}>
               <div className="pt-2 pb-3 space-y-1">
@@ -266,10 +266,10 @@ export default function Layout() {
                         </span>
                       </div>
                     </div>
-                    <div className="ml-3 flex-1">
+                    <div className="ml-3 flex-1 min-w-0">
                       <div className={classNames(
                         branding.isESystemsMode ? "text-white" : "text-gray-900",
-                        "text-base font-medium"
+                        "truncate text-base font-medium"
                       )}>{user.email}</div>
                     </div>
                     <button
@@ -352,7 +352,7 @@ export default function Layout() {
         <div className="container mx-auto py-12 px-4 sm:px-6 lg:px-8">
           <div className="md:flex md:items-center md:justify-between">
             <div className="flex justify-center md:order-2">
-              <div className="flex space-x-6">
+              <div className="flex flex-wrap justify-center gap-x-6 gap-y-3">
                 <Link to="/terms" className="text-gray-700 hover:text-gray-700 text-sm">
                   Terms of Service
                 </Link>

--- a/esystems-frontend/src/components/VACard.js
+++ b/esystems-frontend/src/components/VACard.js
@@ -80,12 +80,12 @@ export default function VACard({ va }) {
   return (
     <>
       <Link to={`/vas/${va._id}`} className="va-card  rounded-lg">
-          <div className="flex items-center rounde-xl bg-stone-100 px-6 p-10 justify-between">
-            <div className="flex items-center max-w-[40%] w-[40%] pr-[30px]">
+          <div className="flex flex-col gap-6 rounde-xl bg-stone-100 p-4 sm:p-6 lg:flex-row lg:items-center lg:justify-between lg:p-10">
+            <div className="flex w-full min-w-0 items-center pr-0 lg:max-w-[40%] lg:w-[40%] lg:pr-[30px]">
               <div className="flex-shrink-0">
                 {va.avatar ? (
                   <img
-                    className="va-profile-pic rounded-full h-[150px] max-w-[150px] w-48"
+                    className="va-profile-pic h-20 w-20 flex-shrink-0 rounded-full object-cover sm:h-[150px] sm:max-w-[150px] sm:w-48"
                     src={va.avatar}
                     alt={va.name}
                   />
@@ -97,25 +97,25 @@ export default function VACard({ va }) {
                   </div>
                 )}
               </div>
-              <div className="ml-6">
+              <div className="ml-4 min-w-0 flex-1 sm:ml-6">
                 <div className="text-sm font-medium text-gray-900">
-                  <h2 className='va-card-title-va-name'>
+                  <h2 className='va-card-title-va-name break-words'>
                     {va.name?.split(' ')[0]}
                   </h2>
                   {va.yearsOfExperience && (
-                    <span className="ml-2 text-xs text-gray-700">
+                    <span className="ml-2 whitespace-nowrap text-xs text-gray-700">
                       • {va.yearsOfExperience} years exp
                     </span>
                   )}
                 </div>
-                <div className="text-sm text-gray-700 va-role">{va.hero}</div>
+                <div className="text-sm text-gray-700 va-role break-words">{va.hero}</div>
               </div>
             </div>
               
-            <div className="flex va-categories-wrapper pl-[20px] align-center max-w-[20%] w-[20%] items-center">
-                <div className="flex column items-center text-sm text-gray-700">
+            <div className="flex va-categories-wrapper w-full min-w-0 items-center pl-0 lg:max-w-[20%] lg:w-[20%] lg:pl-[20px]">
+                <div className="flex column min-w-0 items-start text-sm text-gray-700 lg:items-center">
                   {va.specialties?.length > 0 && (
-                    <ul className="va-capabilities flex flex-col">
+                    <ul className="va-capabilities flex min-w-0 flex-col break-words">
                       {va.specialties.slice(0, 2).map(s => (
                         <li key={s.name}>{s.name}</li>
                       ))}
@@ -127,7 +127,7 @@ export default function VACard({ va }) {
                 </div>
             </div>
 
-            <div className="flex va-video-wrapper items-center align-center justify-center max-w-[20%] w-[20%]">
+            <div className="flex va-video-wrapper w-full items-center justify-start lg:max-w-[20%] lg:w-[20%] lg:justify-center">
                 <div className="text-sm text-gray-700">
                   {va.videoIntroduction ? (
                     <div
@@ -135,7 +135,7 @@ export default function VACard({ va }) {
                       onClick={handleImageClick}
                     >
                       <img
-                        className="w-42 h-[140px] object-cover rounded-lg"
+                        className="h-32 w-full max-w-[180px] object-cover rounded-lg lg:h-[140px]"
                         src={'https://blocks.astratic.com/img/general-video.png'}
                         alt={`${va.name} video thumbnail`}
                       />
@@ -153,7 +153,7 @@ export default function VACard({ va }) {
                 </div>
             </div>
 
-            <div className="flex flex-col items-end space-y-2 max-w-[20%] w-[20%]">
+            <div className="flex w-full flex-col items-stretch gap-2 lg:max-w-[20%] lg:w-[20%] lg:items-end">
 
               {/* {getStatusBadge()}
               {va.industry && va.industry.toLowerCase() !== 'other' && (
@@ -353,4 +353,4 @@ export default function VACard({ va }) {
       )}
     </>
   );
-} 
+}

--- a/esystems-frontend/src/index.css
+++ b/esystems-frontend/src/index.css
@@ -5,14 +5,30 @@
 @layer base {
   html {
     @apply h-full bg-gray-50;
+    overflow-x: hidden;
   }
   
   body {
     @apply h-full;
+    overflow-x: hidden;
   }
   
   #root {
     @apply h-full;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+
+  *, *::before, *::after {
+    min-width: 0;
+  }
+
+  img, video, canvas, svg {
+    max-width: 100%;
+  }
+
+  p, h1, h2, h3, h4, h5, h6, a, span, label {
+    overflow-wrap: anywhere;
   }
 }
 
@@ -105,4 +121,12 @@
   background: inherit;
   border-radius: inherit;
   animation: pulse-ring 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@media (max-width: 640px) {
+  .Toastify__toast-container {
+    left: 0.75rem;
+    right: 0.75rem;
+    width: auto;
+  }
 }

--- a/esystems-frontend/src/pages/Admin/ModerationDashboard.js
+++ b/esystems-frontend/src/pages/Admin/ModerationDashboard.js
@@ -214,10 +214,10 @@ export default function ModerationDashboard() {
 
       {/* Tabs */}
       <div className="border-b border-gray-200 mb-6">
-        <nav className="-mb-px flex space-x-8">
+        <nav className="-mb-px flex gap-8 overflow-x-auto">
           <button
             onClick={() => setActiveTab('queue')}
-            className={`py-2 px-1 border-b-2 font-medium text-sm ${
+            className={`flex-shrink-0 py-2 px-1 border-b-2 font-medium text-sm ${
               activeTab === 'queue'
                 ? 'border-indigo-500 text-indigo-600'
                 : 'border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300'
@@ -227,7 +227,7 @@ export default function ModerationDashboard() {
           </button>
           <button
             onClick={() => setActiveTab('stats')}
-            className={`py-2 px-1 border-b-2 font-medium text-sm ${
+            className={`flex-shrink-0 py-2 px-1 border-b-2 font-medium text-sm ${
               activeTab === 'stats'
                 ? 'border-indigo-500 text-indigo-600'
                 : 'border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300'

--- a/esystems-frontend/src/pages/Admin/NotificationControl.js
+++ b/esystems-frontend/src/pages/Admin/NotificationControl.js
@@ -183,10 +183,10 @@ export default function NotificationControl() {
 
       {/* Tabs */}
       <div className="border-b border-gray-200 mb-6">
-        <nav className="-mb-px flex space-x-8">
+        <nav className="-mb-px flex gap-8 overflow-x-auto">
           <button
             onClick={() => setActiveTab('send')}
-            className={`py-2 px-1 border-b-2 font-medium text-sm ${
+            className={`flex-shrink-0 py-2 px-1 border-b-2 font-medium text-sm ${
               activeTab === 'send'
                 ? 'border-indigo-500 text-indigo-600'
                 : 'border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300'
@@ -196,7 +196,7 @@ export default function NotificationControl() {
           </button>
           <button
             onClick={() => setActiveTab('templates')}
-            className={`py-2 px-1 border-b-2 font-medium text-sm ${
+            className={`flex-shrink-0 py-2 px-1 border-b-2 font-medium text-sm ${
               activeTab === 'templates'
                 ? 'border-indigo-500 text-indigo-600'
                 : 'border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300'
@@ -206,7 +206,7 @@ export default function NotificationControl() {
           </button>
           <button
             onClick={() => setActiveTab('history')}
-            className={`py-2 px-1 border-b-2 font-medium text-sm ${
+            className={`flex-shrink-0 py-2 px-1 border-b-2 font-medium text-sm ${
               activeTab === 'history'
                 ? 'border-indigo-500 text-indigo-600'
                 : 'border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300'

--- a/esystems-frontend/src/pages/Business/ProfileWithTabs.js
+++ b/esystems-frontend/src/pages/Business/ProfileWithTabs.js
@@ -62,7 +62,7 @@ function BusinessProfileWithTabsContent() {
 
             {/* Tab Navigation */}
             <div className="border-b border-gray-200">
-              <nav className="-mb-px flex space-x-8" aria-label="Tabs">
+              <nav className="-mb-px flex gap-8 overflow-x-auto" aria-label="Tabs">
                 {tabs.map((tab) => {
                   const Icon = tab.icon;
                   return (
@@ -70,7 +70,7 @@ function BusinessProfileWithTabsContent() {
                       key={tab.id}
                       onClick={() => setActiveTab(tab.id)}
                       className={`
-                        group inline-flex items-center py-4 px-1 border-b-2 font-medium text-sm
+                        group inline-flex flex-shrink-0 items-center py-4 px-1 border-b-2 font-medium text-sm
                         ${activeTab === tab.id
                           ? 'border-blue-500 text-blue-600'
                           : 'border-transparent text-gray-700 hover:text-gray-700 hover:border-gray-300 cursor-pointer'

--- a/esystems-frontend/src/pages/VAs/Detail.js
+++ b/esystems-frontend/src/pages/VAs/Detail.js
@@ -187,7 +187,7 @@ export default function VADetail() {
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">
             <div className="md:flex md:items-end md:justify-between">
               <div className="flex-1 min-w-0">
-                <div className="flex items-end">
+                <div className="flex min-w-0 items-end">
                   {va.avatar ? (
                     <img
                       className="h-24 w-24 sm:h-32 sm:w-32 rounded-full border-4 border-white shadow-lg object-cover"
@@ -205,21 +205,21 @@ export default function VADetail() {
                       </span>
                     </div>
                   )}
-                  <div className="ml-4 pb-4">
+                  <div className="ml-4 min-w-0 pb-4">
                     <div className="bg-white/90 backdrop-blur-sm rounded-lg px-4 py-2 shadow-sm">
-                      <h1 className="text-2xl font-bold text-gray-900 sm:text-3xl">
+                      <h1 className="break-words text-2xl font-bold text-gray-900 sm:text-3xl">
                         {va.name.charAt(0).toUpperCase() + va.name.slice(1)}
                       </h1>
-                      <p className="text-sm text-gray-600">{va.hero.charAt(0).toUpperCase() + va.hero.slice(1)}</p>
+                      <p className="break-words text-sm text-gray-600">{va.hero.charAt(0).toUpperCase() + va.hero.slice(1)}</p>
                     </div>
                   </div>
                 </div>
               </div>
-              <div className="mt-4 flex md:mt-0 md:ml-4 pb-4 space-x-3">
+              <div className="mt-4 flex flex-col gap-3 pb-4 sm:flex-row sm:flex-wrap md:mt-0 md:ml-4 md:justify-end">
                 <button
                   onClick={handleCreateShareUrl}
                   disabled={isCreatingShare}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 disabled:opacity-50"
+                  className="inline-flex w-full items-center justify-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 disabled:opacity-50 sm:w-auto"
                 >
                   <ShareIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
                   {isCreatingShare ? 'Creating...' : 'Share Profile'}
@@ -232,7 +232,7 @@ export default function VADetail() {
                     {messaging.actionButton.type === 'message' ? (
                       <button
                         onClick={handleStartConversation}
-                        className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+                        className="inline-flex w-full items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 sm:w-auto"
                       >
                         <EnvelopeIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
                         {messaging.actionButton.text || (branding.isESystemsMode ? 'Contact Professional' : 'Start Conversation')}
@@ -240,7 +240,7 @@ export default function VADetail() {
                     ) : messaging.actionButton.type === 'register' ? (
                       <a
                         href={messaging.actionButton.url}
-                        className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                        className="inline-flex w-full items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:w-auto"
                       >
                         <ChatBubbleLeftIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
                         {messaging.actionButton.text}
@@ -248,7 +248,7 @@ export default function VADetail() {
                     ) : messaging.actionButton.type === 'complete_profile' ? (
                       <a
                         href={messaging.actionButton.url}
-                        className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-yellow-600 hover:bg-yellow-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500"
+                        className="inline-flex w-full items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-yellow-600 hover:bg-yellow-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500 sm:w-auto"
                       >
                         <ChatBubbleLeftIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
                         {messaging.actionButton.text}
@@ -260,7 +260,7 @@ export default function VADetail() {
                 {!messaging?.actionButton && isBusiness && (
                   <button
                     onClick={handleStartConversation}
-                    className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+                    className="inline-flex w-full items-center justify-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-gray-600 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500 sm:w-auto"
                   >
                     <EnvelopeIcon className="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
                     {branding.isESystemsMode ? 'Contact Professional' : 'Start Conversation'}
@@ -708,8 +708,8 @@ export default function VADetail() {
 
       {/* Share Modal */}
       {showShareModal && shareUrl && (
-        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
-          <div className="relative top-20 mx-auto p-6 border w-full max-w-md shadow-lg rounded-lg bg-white">
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 p-4">
+          <div className="relative top-8 mx-auto w-full max-w-md rounded-lg border bg-white p-4 shadow-lg sm:top-20 sm:p-6">
             <div className="text-center">
               <div className="flex items-center justify-center w-12 h-12 mx-auto bg-blue-100 rounded-full mb-4">
                 <ShareIcon className="h-6 w-6 text-blue-600" />
@@ -717,7 +717,7 @@ export default function VADetail() {
               <h3 className="text-lg font-semibold text-gray-900 mb-2">Share this profile with your network</h3>
               
               {/* Social Media Sharing Buttons */}
-              <div className="flex justify-center space-x-3 mb-6">
+              <div className="mb-6 flex flex-wrap justify-center gap-3">
                 {/* Facebook */}
                 <button
                   onClick={() => {
@@ -802,12 +802,12 @@ export default function VADetail() {
 
               {/* URL Display */}
               <div className="mb-4">
-                <div className="flex items-center border border-gray-300 rounded-md p-3 bg-gray-50">
+                <div className="flex min-w-0 items-center border border-gray-300 rounded-md p-3 bg-gray-50">
                   <input
                     type="text"
                     value={shareUrl}
                     readOnly
-                    className="flex-1 bg-transparent text-sm text-gray-600 focus:outline-none"
+                    className="min-w-0 flex-1 bg-transparent text-sm text-gray-600 focus:outline-none"
                   />
                 </div>
               </div>
@@ -826,8 +826,8 @@ export default function VADetail() {
 
       {/* Chat Modal */}
       {showChatModal && (
-        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
-          <div className="relative top-20 mx-auto p-5 border w-full max-w-lg shadow-lg rounded-md bg-white">
+        <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 p-4">
+          <div className="relative top-8 mx-auto w-full max-w-lg rounded-md border bg-white p-4 shadow-lg sm:top-20 sm:p-5">
             <div className="mt-3">
               <div className="flex items-center justify-center w-12 h-12 mx-auto bg-blue-100 rounded-full">
                 <ChatBubbleLeftIcon className="h-6 w-6 text-blue-600" />
@@ -848,7 +848,7 @@ export default function VADetail() {
                     onChange={(e) => setChatMessage(e.target.value)}
                   />
                 </div>
-                <div className="mt-6 flex justify-center space-x-3">
+                <div className="mt-6 flex flex-col justify-center gap-3 sm:flex-row">
                   <button
                     onClick={() => {
                       setShowChatModal(false);


### PR DESCRIPTION
## Summary
- Fix Linkage VA Hub responsive navigation so crowded desktop links stay behind the mobile menu until desktop widths.
- Make the current `dev` VA card layout stack safely on phones while preserving the desktop multi-column design.
- Make VA profile headers/actions, share/chat modals, footer links, and tab bars wrap or scroll safely on small screens.
- Add mobile guardrails for long text/media and toast container width.

## OPPM
- Feedback: #400
- Paperclip issue: MUR-853

## Verification
- `npm run build` in `esystems-frontend` passed on this `dev`-based branch with existing lint warnings.
- Playwright MCP local mobile audit passed with no horizontal overflow on public routes at 390px and 320px: `/`, `/how-it-works`, `/pricing`, `/vas`, `/community`, `/about`, `/sign-in`, `/sign-up`, `/terms`, `/privacy`.
- Playwright MCP tablet audit passed with no horizontal overflow at 768px, 820px, and 1024px, including protected-route redirects.
- Playwright MCP VA list/detail fixture audit passed with no horizontal overflow at 390px, 320px, and 768px.
- Screenshot captured: `mur-853-mobile-va-detail-local.png`.

## Database
- No database changes.

## Deployment note
- Render Linkage services are configured to deploy from `dev`, so this PR targets `dev`.