### PR TITLE
fix: prevent community mobile phone input overflow

### DIFF
--- a/frontend/src/pages/Community.js
+++ b/frontend/src/pages/Community.js
@@ -752,7 +752,7 @@ export default function Community() {
 
                   <div className="flex flex-col gap-1">
                     <label htmlFor="messenger" className="text-sm font-medium">Philippine phone number</label>
-                    <div className="flex">
+                    <div className="flex min-w-0">
                       <span className="inline-flex items-center px-3 rounded-l border border-r-0 border-gray-300 bg-gray-50 text-gray-500 text-sm">
                         +63
                       </span>
@@ -767,7 +767,7 @@ export default function Community() {
                           setFormData({...formData, messenger: value});
                         }}
                         placeholder="9XX XXX XXXX"
-                        className="flex-1 rounded-r border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        className="min-w-0 flex-1 rounded-r border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                       />
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Fix the deployed Linkage `frontend/src/pages/Community.js` webinar phone input row that still overflowed at 320px after the first mobile pass.
- Adds `min-w-0` to the prefix/input flex row and the input so it can shrink within the card.

## OPPM
- Feedback: #400
- Paperclip issue: MUR-853

## Verification
- `npm run build` in `frontend` passed with existing lint warnings.
- Live Playwright verification before this patch identified the only remaining overflow: `/community` at 320px, caused by the phone input row.

## Database
- No database changes.